### PR TITLE
Adds a queue to help prevent duplicate notifications and timeouts.

### DIFF
--- a/notify/handler.py
+++ b/notify/handler.py
@@ -25,6 +25,9 @@ import webapp2
 from apiclient.http import MediaIoBaseUpload
 from oauth2client.appengine import StorageByKeyName
 
+from google.appengine.api import urlfetch, taskqueue
+import httplib2
+
 from model import Credentials
 import util
 
@@ -33,7 +36,23 @@ class NotifyHandler(webapp2.RequestHandler):
   """Request Handler for notification pings."""
 
   def post(self):
+    # Add the task to the default queue.
+
+    logging.info('Queuing request with payload %s', self.request.body)
+
+    taskqueue.add(url='/worker', payload=self.request.body)
+
+
+
+class WorkerHandler(webapp2.RequestHandler):
+  """Request Handler for worker pings."""
+
+  def post(self):
     """Handles notification pings."""
+
+    urlfetch.set_default_fetch_deadline(45)
+    httplib2.Http(timeout=45) 
+
     logging.info('Got a notification with payload %s', self.request.body)
     data = json.loads(self.request.body)
     userid = data['userToken']
@@ -94,5 +113,6 @@ class NotifyHandler(webapp2.RequestHandler):
 
 
 NOTIFY_ROUTES = [
-    ('/notify', NotifyHandler)
+    ('/notify', NotifyHandler),
+    ('/worker', WorkerHandler)
 ]


### PR DESCRIPTION
This makes the fetching the media much more reliable for me. Generally I
would see requests to the Mirror Attachment API take about 10 seconds.
The default timeout is 5 seconds.

By moving the code that fetches the image to a queue, the response back to the
Google API happens almost immediately. This helps prevent duplicates and
eliminates most timeouts.
