### PR TITLE
docs: Fix a few typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ accept your pull requests.
 1. Sign a Contributor License Agreement, if you have not yet done so (see
    details above).
 1. Create your own repo for your app following this naming convention:
-    * mirror-{app-name}-{language or plaform}
+    * mirror-{app-name}-{language or platform}
     * apps: quickstart, photohunt-server, photohunt-client
     * example:  mirror-quickstart-android
     * For multi-language apps, concatenate the primary languages like this:

--- a/oauth/handler.py
+++ b/oauth/handler.py
@@ -96,7 +96,7 @@ class OAuthCodeExchangeHandler(OAuthBaseRequestHandler):
     self.redirect('/')
 
   def _perform_post_auth_tasks(self, userid, creds):
-    """Perform commong post authorization tasks.
+    """Perform common post authorization tasks.
 
     Subscribes the service to notifications for the user and add one sharing
     contact.


### PR DESCRIPTION
There are small typos in:
- CONTRIBUTING.md
- oauth/handler.py

Fixes:
- Should read `platform` rather than `plaform`.
- Should read `common` rather than `commong`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md